### PR TITLE
Fix style issues and clean imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ If you are running this on Windows, make sure **Microsoft Word is installed** (f
 
 ## ▶️ How to Run the Script
 
+> **Note**
+> The main script is now named `autopdfbinder.py` (formerly
+> `enhanced-document-generator.py`). A small wrapper with the old name is
+> included for backward compatibility, so either file can be launched.
+
 ### **Step 1: Prepare Your Files**
 
 1. Place all your **Word (.docx) and PDF (.pdf) files** in a single folder.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Ideal for **lawyers, paralegals, and legal assistants — saving hours of manual
 
 ### **Download the Script**
 
-1. Go to the [GitHub Releases](https://github.com/Zippysquid/AutoPDFBinder/releases) page.
-2. Download the latest **AutoPDFBinder.zip** file.
-3. Extract the ZIP file to a convenient location on your computer (e.g., `C:\AutoPDFBinder`).
+1. Clone or download this repository to a folder of your choice (e.g., `C:\AutoPDFBinder`).
 
 ### **Requirements**
 
@@ -59,8 +57,8 @@ If you are running this on Windows, make sure **Microsoft Word is installed** (f
 #### **Windows (Double Click Method)**
 
 1. Navigate to the folder where you extracted **AutoPDFBinder**.
-2. Locate the **script.py** file.
-3. **Right-click** on `script.py` and select **Open with > Python** (or double-click if Python is set as the default).
+2. Locate the **autopdfbinder.py** file.
+3. **Right-click** on `autopdfbinder.py` and select **Open with > Python** (or double-click if Python is set as the default).
 
 #### **Command Line Method (Recommended for Logs)**
 
@@ -71,7 +69,7 @@ If you are running this on Windows, make sure **Microsoft Word is installed** (f
    ```
 3. Run the script:
    ```sh
-   python script.py
+   python autopdfbinder.py
    ```
 
 ### **Step 3: Output Files**
@@ -146,6 +144,6 @@ To run this script in GitHub Codespaces:
 3. Place all Word and PDF files in your working directory.
 4. Execute the script:
    ```sh
-   python script.py
+   python autopdfbinder.py
    ```
 5. Download `final_output.pdf` from the workspace when processing is complete.

--- a/enhanced-document-generator.py
+++ b/enhanced-document-generator.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for the renamed script.
+
+This module forwards execution to ``autopdfbinder`` for users accustomed to
+launching ``enhanced-document-generator.py``. The primary functionality now
+lives in :mod:`autopdfbinder`.
+"""
+
+from autopdfbinder import main
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+docx
+PyPDF2
+PyMuPDF
+comtypes


### PR DESCRIPTION
## Summary
- clean imports in `autopdfbinder.py`
- add spacing for PEP8 compliance
- wrap long lines and improve docstrings
- break up comprehension blocks for readability
- add Windows/Word checks so the script exits with a clear error

## Testing
- `python -m py_compile autopdfbinder.py`
- `flake8 autopdfbinder.py`


------
https://chatgpt.com/codex/tasks/task_b_6843d6c0f1148330903dd4b890d17acb